### PR TITLE
Fix quoting in telegraf_downsample_day

### DIFF
--- a/influxdb/setup/tasks/telegraf_downsample_day
+++ b/influxdb/setup/tasks/telegraf_downsample_day
@@ -3,4 +3,4 @@ option task = {name: "telegraf_downsample_day", every: 1m}
 from(bucket: "telegraf/actual")
     |> range(start: -task.every)
     |> aggregateWindow(every: 1m, fn: mean)
-    |> to(org: $DOCKER_INFLUXDB_INIT_ORG, bucket: "telegraf/day")
+    |> to(org: "$DOCKER_INFLUXDB_INIT_ORG", bucket: "telegraf/day")


### PR DESCRIPTION
Got Error: 400 Bad Request: invalid options: loc 6:17-6:41: invalid expression @6:16-6:17: $ while executing the setup due to missing quotation.